### PR TITLE
develop

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    alias(libs.plugins.android.application) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false
     alias(libs.plugins.android.library) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,23 +1,11 @@
 [versions]
-agp = "8.4.1"
+agp = "8.4.2"
 kotlin = "1.9.0"
 coreKtx = "1.13.1"
-junit = "4.13.2"
-junitVersion = "1.2.1"
-espressoCore = "3.6.1"
-appcompat = "1.7.0"
-material = "1.12.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
-junit = { group = "junit", name = "junit", version.ref = "junit" }
-androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
-androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
-androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 
 [plugins]
-android-application = { id = "com.android.application", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "agp" }
-

--- a/ui-transferable-text/build.gradle.kts
+++ b/ui-transferable-text/build.gradle.kts
@@ -36,7 +36,7 @@ configure<PublishingExtension> {
     publications.create<MavenPublication>("ui-transferable-text") {
         groupId = "com.github.dorianpavetic"
         artifactId = "ui-transferable-text"
-        version = "1.0.3"
+        version = "1.0.4"
         pom {
             name.set("ui-transferable-text")
             description.set(

--- a/ui-transferable-text/src/main/java/hr/dorianpavetic/ui_transferable_text/text/UiTransferableText.kt
+++ b/ui-transferable-text/src/main/java/hr/dorianpavetic/ui_transferable_text/text/UiTransferableText.kt
@@ -58,10 +58,8 @@ interface UiTransferableText : Serializable {
             private fun prependSeparator(
                 separator: CharSequence = ", ",
                 texts: List<UiTransferableText>
-            ) : List<UiTransferableText> {
-                val mutableList = if (texts is MutableList) texts else texts.toMutableList()
-                mutableList.add(0, text(separator))
-                return mutableList
+            ) = texts.toMutableList().also {
+                it.add(0, text(separator))
             }
         }
 


### PR DESCRIPTION
fix: Combined text separator prepend
- Fix prepending separator to existing list of arguments
  - Bug appeared because list can not be properly tested with `is MutableList` as it is only fictional in Kotlin - compiles to `List` in Java. In those cases, code would try to use `add()` on immutable list and would result in `UnsupportedOperationException`
- Cleanup unused dependency versions
- Bump version to `1.0.4`