### PR TITLE
1.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 [![](https://jitpack.io/v/dorianpavetic/ui-transferable-text.svg)](https://jitpack.io/#dorianpavetic/ui-transferable-text)
 
 # ui-transferable-text
-Library which enables passing localized text between Android context-aware and contextless components - e.g. between ViewModel and Fragment
+Library which enables passing localized text between Android context-aware and context-less components - e.g. between ViewModel and Fragment
 Functionalities can be easily extended using Kotlin extensions and custom implementations of `UiTransferableText` interface.
 
 ## Getting started
 To start using library, add dependency to your Android gradle file (not root one):
 ```
 dependencies {
-  implementation 'com.github.dorianpavetic:ui-transferable-text:v1.0.0'
+  implementation 'com.github.dorianpavetic:ui-transferable-text:v1.0.5'
 }
 ```
 
@@ -183,7 +183,24 @@ private fun getAllowedPetsTypesWithRestrictionText(
  }
 ```
 
+### LazyResolvable
+
+```kotlin
+import java.time.LocalDate
+import java.time.LocalTime
+
+// Resolves to different formatting based on context and locale, e.g. for English: "10 - 11 AM"
+val formattedTimeRangeLazyResolvable = UiTransferableText.lazyResolvable { context: Context ->
+    TimeRangeUtils.formatForLocalizedDisplay(
+        context, LocalTime.of(10, 0), LocalTime.of(11, 0),
+    )
+}
+// ...
+// Later in code when Context is available, e.g. Fragment
+binding.textView.text = formattedTimeRangeLazyResolvable.getText(context)
+```
+
 ## Medium
-This library is result of the Medium article, where you can see more detailed explainations of library code:
+This library is result of the Medium article, where you can see more detailed explanations of library code:
 https://medium.com/@dorianpavetic/android-localize-text-in-viewmodel-f1521aff3583
 

--- a/ui-transferable-text/build.gradle.kts
+++ b/ui-transferable-text/build.gradle.kts
@@ -36,7 +36,7 @@ configure<PublishingExtension> {
     publications.create<MavenPublication>("ui-transferable-text") {
         groupId = "com.github.dorianpavetic"
         artifactId = "ui-transferable-text"
-        version = "1.0.4"
+        version = "1.0.5"
         pom {
             name.set("ui-transferable-text")
             description.set(

--- a/ui-transferable-text/src/main/java/hr/dorianpavetic/ui_transferable_text/text/SeparatableUiTransferableText.kt
+++ b/ui-transferable-text/src/main/java/hr/dorianpavetic/ui_transferable_text/text/SeparatableUiTransferableText.kt
@@ -1,0 +1,41 @@
+package hr.dorianpavetic.ui_transferable_text.text
+
+import android.content.Context
+
+/**
+ * Special [UiTransferableText] type that containerizes multiple
+ * items and can use separator.
+ *
+ * - Separator is always first value in the list
+ * - By default, when resolving [getText], [textList] is joined
+ * by resolved [separator].
+ */
+interface SeparatableUiTransferableText<T>: UiTransferableText {
+
+    val value: Collection<T>
+
+    val textList: List<T>
+        get() = value.drop(1)
+
+    val separator: T
+        get() = value.first()
+
+    fun resolveSingleItemText(context: Context, item: T, isSeparator: Boolean): CharSequence
+
+    override fun getText(context: Context): CharSequence {
+        val separatorText = this.resolveSingleItemText(context, separator, true)
+        return value.joinToString(separatorText) { this.resolveSingleItemText(context, it, false) }
+    }
+
+    companion object {
+        const val DEFAULT_SEPARATOR = ", "
+
+        fun <T> prependSeparator(
+            separator: T,
+            textList: List<T>
+        ) = textList.toMutableList().also {
+            it.add(0, separator)
+        }
+    }
+
+}

--- a/ui-transferable-text/src/main/java/hr/dorianpavetic/ui_transferable_text/text/UiTransferableText.kt
+++ b/ui-transferable-text/src/main/java/hr/dorianpavetic/ui_transferable_text/text/UiTransferableText.kt
@@ -35,6 +35,8 @@ interface UiTransferableText : Serializable {
         fun stringResIdList(@StringRes values: Collection<Int>) = StringResIdList(values)
 
         fun text(value: CharSequence) = Text(value)
+
+        fun lazyResolvable(resolveFunction: (Context) -> CharSequence) = LazyResolvable(resolveFunction)
     }
 
 
@@ -156,6 +158,13 @@ interface UiTransferableText : Serializable {
         val text: CharSequence
     ) : UiTransferableText {
         override fun getText(context: Context) = text
+    }
+
+    @JvmInline
+    value class LazyResolvable(
+        private val resolveFunction: (Context) -> CharSequence
+    ) : UiTransferableText {
+        override fun getText(context: Context) = resolveFunction.invoke(context)
     }
 
 }


### PR DESCRIPTION
### LazyResolvable
- Add new data type that allows passing function that can be resolved at runtime when `getText(Context)` is called - for example, when `Context` is actually known and passed
  - Use case: when resolving text that requires `Context`
- Add example for `LazyResolvable`


### Separatable
- Add new `SeparatableUiTransferableText` interface that encapsulates logic about `List` containerized `UiTransferableText` that is joined into a single list and requires separator
  - This feature enables specifying `separator` for all types of (previous) `UiTransferableText` that uses `List` as values
  - Previously, only `Combined` was using it, now `StringResId` also supports it
    - If no separator is specified, `DEFAULT_SEPARATOR` is used - ", "
