### PR TITLE
fix: SeparatableUiTransferableText

### DIFF
--- a/ui-transferable-text/build.gradle.kts
+++ b/ui-transferable-text/build.gradle.kts
@@ -36,7 +36,7 @@ configure<PublishingExtension> {
     publications.create<MavenPublication>("ui-transferable-text") {
         groupId = "com.github.dorianpavetic"
         artifactId = "ui-transferable-text"
-        version = "1.0.5"
+        version = "1.0.6"
         pom {
             name.set("ui-transferable-text")
             description.set(

--- a/ui-transferable-text/src/main/java/hr/dorianpavetic/ui_transferable_text/text/SeparatableUiTransferableText.kt
+++ b/ui-transferable-text/src/main/java/hr/dorianpavetic/ui_transferable_text/text/SeparatableUiTransferableText.kt
@@ -24,7 +24,7 @@ interface SeparatableUiTransferableText<T>: UiTransferableText {
 
     override fun getText(context: Context): CharSequence {
         val separatorText = this.resolveSingleItemText(context, separator, true)
-        return value.joinToString(separatorText) { this.resolveSingleItemText(context, it, false) }
+        return textList.joinToString(separatorText) { this.resolveSingleItemText(context, it, false) }
     }
 
     companion object {


### PR DESCRIPTION
Fix a bug where values for `SeparatableUiTransferableText` text was extracted from `value` rather than from `textList`